### PR TITLE
Intruduce optional mode parameter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   Exclude:
     - 'gemfiles/*.gemfile'
     - 'vendor/**/*'
+    - 'spec/**/*'
 
 Style/Documentation:
   Enabled: false

--- a/lib/moments.rb
+++ b/lib/moments.rb
@@ -5,7 +5,7 @@ require_relative 'moments/difference'
 
 # Entrypoint for the moments gem
 module Moments
-  def self.difference(from, to)
-    Moments::Difference.new from, to
+  def self.difference(from, to, mode = :normal)
+    Moments::Difference.new from, to, mode
   end
 end

--- a/lib/moments/difference.rb
+++ b/lib/moments/difference.rb
@@ -21,12 +21,15 @@ module Moments
 
     # == Parameters:
     # from::
-    #   A instance of Time
+    #   An instance of Time
     # to::
-    #   A instance of Time
-    def initialize(from, to)
+    #   An instance of Time
+    # precise::
+    #   Option to return minutes, hours, days, years as decimals intead of integer
+    def initialize(from, to, mode = :normal)
       @from = parse_argument from
       @to = parse_argument to
+      @precise = mode == :precise
 
       @ordered_from, @ordered_to = [@from, @to].sort
 
@@ -54,19 +57,19 @@ module Moments
     end
 
     def in_minutes
-      in_seconds / 60
+      in_seconds / (@precise ? 60.0 : 60)
     end
 
     def in_hours
-      in_minutes / 60
+      in_minutes / (@precise ? 60.0 : 60)
     end
 
     def in_days
-      in_hours / 24
+      in_hours / (@precise ? 24.0 : 24)
     end
 
     def in_weeks
-      in_days / 7
+      in_days / (@precise ? 7.0 : 7)
     end
 
     def in_months

--- a/spec/lib/moments/difference_precision_spec.rb
+++ b/spec/lib/moments/difference_precision_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe Moments::Difference do
+  # Thu, 04 Aug 2022 15:52:25 MDT -06:00
+  let(:from) { Time.new(2022, 8, 4, 15, 52, 25, '-06:00') }
+  # Thu, 18 Aug 2022 15:52:31 MDT -06:00
+  let(:to) { Time.new(2022, 8, 18, 15, 52, 31, '-06:00') }
+
+  describe 'minutes' do
+    context 'precision' do
+      subject { Moments.difference(from, to, :precise).in_minutes }
+
+      it { should eq 20_160.1 }
+    end
+  end
+
+  describe 'hours' do
+    context 'precision' do
+      subject { Moments.difference(from, to, :precise).in_hours }
+
+      it { should eq 336.001666666666667 }
+    end
+  end
+
+  describe 'days' do
+    context 'precision' do
+      subject { Moments.difference(from, to, :precise).in_days }
+
+      it { should eq 14.000069444444444 }
+    end
+  end
+
+  describe 'weeks' do
+    context 'precision' do
+      subject { Moments.difference(from, to, :precise).in_weeks }
+
+      it { should eq 2.0000099206349207 }
+    end
+  end
+end


### PR DESCRIPTION
If mode parameter is set to `:precise` all calculations will return decimal numbers instead of integer numbers.

Example:
```ruby
from Time.new(2022, 8, 4, 15, 52, 25, '-06:00')
to = Time.new(2022, 8, 18, 15, 52, 31, '-06:00')

difference = Moments.difference(from, to, :precise).in_minutes

# returns: 20_160.1
```